### PR TITLE
add event click on wrapper

### DIFF
--- a/src/Avatar.svelte
+++ b/src/Avatar.svelte
@@ -71,7 +71,7 @@
   }
 </style>
 
-<div
+<div on:click
   aria-label={name}
   class="wrapper"
   style="{style}--borderRadius:{square ? 0 : borderRadius}; --size:{size}; --bgColor:{background};


### PR DESCRIPTION
Hi! 👋 
      
Firstly, thanks for your work on this project! 🙂

Today I used [patch-package](https://github.com/ds300/patch-package) to patch `svelte-avatar@1.1.1` for the project I'm working on.

Very often work for avatar is option to be clickable. With this small addition, I don't need anymore, use my own wrapper around your wrapper. It's also not mandatory, so forwarding the event to it is optional.

Here is the diff that solved my problem:

```diff
@@ -71,7 +71,7 @@
   }
 </style>
 
-<div
+<div on:click
   aria-label={name}
   class="wrapper"
   style="{style}--borderRadius:{square ? 0 : borderRadius}; --size:{size}; --bgColor:{background};
```

<em>This issue body was [partially generated by patch-package](https://github.com/ds300/patch-package/issues/296).</em>